### PR TITLE
Fix for flushQueue db fetchAll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor/
 /build/
 /composer.lock
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /vendor/
 /build/
 /composer.lock
-
-.idea/

--- a/src/Swift_PdoSpool.php
+++ b/src/Swift_PdoSpool.php
@@ -139,7 +139,7 @@ class Swift_PdoSpool extends Swift_ConfigurableSpool
                 . $this->timeField . ' = ? WHERE ' . $this->pkey . ' = ?');
             $dstmt = $this->pdo->prepare('DELETE FROM ' . $this->table . ' WHERE '
                 . $this->pkey . ' = ?');
-            foreach ($results->fetchAll(PDO::FETCH_COLUMN) as $result) {
+            foreach ($results->fetchAll() as $result) {
                 $id = $result[0];
                 $ustmt->execute(array(time(), $result[0]));
                 $message = unserialize($result[1]);


### PR DESCRIPTION
While testing this in development of the email utility feature I discovered the original fork's `flushQueue` did not fetch the serialized emails from the database as intended. Using `PDO::FETCH_COLUMN` resulted in a `unserialize` failure.